### PR TITLE
Fixes for pedantic compiler options, consistency and tidiness

### DIFF
--- a/include/BtOgreExtras.h
+++ b/include/BtOgreExtras.h
@@ -17,6 +17,7 @@
 #define _BtOgreShapes_H_
 
 #include "btBulletDynamicsCommon.h"
+#include "OgreSceneNode.h"
 #include "OgreSimpleRenderable.h"
 #include "OgreCamera.h"
 #include "OgreHardwareBufferManager.h"

--- a/include/BtOgreGP.h
+++ b/include/BtOgreGP.h
@@ -24,7 +24,7 @@
 namespace BtOgre {
 
 typedef std::map<unsigned char, Vector3Array*> BoneIndex;
-typedef std::pair<unsigned short, Vector3Array*> BoneKeyIndex;
+typedef std::pair<unsigned char, Vector3Array*> BoneKeyIndex;
 
 class VertexIndexToShape
 {


### PR DESCRIPTION
This set allows BtOgre to be compiled with -Wall -Wextra -pedantic. You had the member order a little wrong.

Next, consistency and tidiness fixes for line endings (which were a mix of DOS and UNIX line endings) and lots of trailing spaces removed.

Also I changed the names for the README and LICENSE files because these are the expected and rather common names.
