### PR TITLE
CMakeLists.txt: allow consuming as 'sub project'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,13 @@ cmake_minimum_required(VERSION 2.8.0)
 
 project(BtOgre)
 
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake-extras/)
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake-extras/)
 
 find_package(Bullet REQUIRED)
 find_package(OGRE REQUIRED)
 
 include_directories(
-    ${CMAKE_SOURCE_DIR}/include/
+    ${PROJECT_SOURCE_DIR}/include/
     ${BULLET_INCLUDE_DIRS}
     ${OGRE_INCLUDE_DIRS}
 )


### PR DESCRIPTION
Paths are now relative to PROJECT, rather than CMAKE, which allows embedding the project within another CMake project directly (rather than building it separately).
